### PR TITLE
Fixed `secret reference` link

### DIFF
--- a/content/usage/pipeline/steps/secrets.md
+++ b/content/usage/pipeline/steps/secrets.md
@@ -71,4 +71,4 @@ steps:
 
 ### Reference Secret
 
-Vela offers a number of different ways to reference your secrets. To see the full set of options navigate to the [secret reference](/usage/reference/secrets) section.
+Vela offers a number of different ways to reference your secrets. To see the full set of options navigate to the [secret reference](/usage/reference/pipeline/secret/) section.


### PR DESCRIPTION
Currently points to the `secret` section of Pipeline, but could point towards the same section in `CLI`, `API`, and `Go SDK`